### PR TITLE
Logging falls back to internal flash if SD card not detected.

### DIFF
--- a/src/FSCommon.cpp
+++ b/src/FSCommon.cpp
@@ -6,6 +6,7 @@
 #include <SD.h>
 #include "SPILock.h"
 
+#include "MasterLogger.h"
 
 #ifdef SDCARD_USE_SPI1  
 //SPIClass SPI1(HSPI);
@@ -190,6 +191,7 @@ void setupSDCard()
     concurrency::LockGuard g(spiLock);
     if (!SD.begin(SDCARD_CS, SDHandler, 4000000, "/sd", 5, true)) {
         DEBUG_MSG("No SD_MMC card detected\n");
+        MasterLogger::useFallbackFS();
         return ;
     }
     uint8_t cardType = SD.cardType();

--- a/src/MasterLogger.cpp
+++ b/src/MasterLogger.cpp
@@ -78,7 +78,7 @@ void MasterLogger::writeData(LogData& data) {
 bool MasterLogger::readLog(String& outLog) {
     {
         concurrency::LockGuard g(spiLock);
-        File masterFile = SD.open(MASTER_FILE_NAME, "r");
+        File masterFile = filesystem->open(MASTER_FILE_NAME, "r");
         if(!masterFile) {
             return false;
         }

--- a/src/MasterLogger.cpp
+++ b/src/MasterLogger.cpp
@@ -1,6 +1,7 @@
 #include "MasterLogger.h"
 
 #include <SD.h>
+#include <FSCommon.h>
 
 #include <cstdarg>
 #include <cstring>
@@ -8,6 +9,16 @@
 #include <ctime>
 
 #include "SPILock.h"
+
+FS* MasterLogger::filesystem = &SD;
+
+void MasterLogger::useFallbackFS() {
+    filesystem = &FSCom;
+}
+
+void MasterLogger::useSDFS() {
+    filesystem = &SD;
+}
 
 void MasterLogger::writeString(const char* message, ...) {
     // 4K should be enough space for a log entry...
@@ -23,9 +34,9 @@ void MasterLogger::writeString(const char* message, ...) {
     // Open master file as write (defaults to appending)
     {
         concurrency::LockGuard g(spiLock);
-        File masterFile = SD.open(MASTER_FILE_NAME, "a");
+        File masterFile = filesystem->open(MASTER_FILE_NAME, "a");
         if(!masterFile) {
-            masterFile = SD.open(MASTER_FILE_NAME, "w", true);
+            masterFile = filesystem->open(MASTER_FILE_NAME, "w", true);
         }
         if(masterFile) {
             masterFile.println(fmtMessage);
@@ -56,7 +67,7 @@ void MasterLogger::writeData(LogData& data) {
     // Open master file as write (defaults to appending)
     {
         concurrency::LockGuard g(spiLock);
-        File masterFile = SD.open(MASTER_FILE_NAME, "w");
+        File masterFile = filesystem->open(MASTER_FILE_NAME, "w");
         if(masterFile) {
             masterFile.println(fmtMessage);
             masterFile.close();

--- a/src/MasterLogger.h
+++ b/src/MasterLogger.h
@@ -4,13 +4,10 @@
 #include "GeoCoord.h"
 
 #include <WString.h>
-
 #include <cstdint>
+#include <FS.h>
 
 #define MASTER_FILE_NAME "/Masterfile.txt"
-
-#define STRING_LOGGING
-#ifdef STRING_LOGGING
 
 class MasterLogger {
 public:
@@ -40,22 +37,9 @@ public:
     static void writeData(LogData& data);
 
     static bool readLog(String& outLog);
+
+    static void useFallbackFS();
+    static void useSDFS();
+private:
+    static FS* filesystem;
 };
-
-#else
-
-class MasterLogger {
-public:
-    struct LogData {
-        GeoCoord gpsData;
-        time_t unixTimeStamp;
-        enum DetectionType {
-            DETECTION_TYPE_HUMAN,
-            DETECTION_TYPE_VEHICLE
-        } detectionType;
-    };
-
-    static void writeByte(LogData data);
-};
-
-#endif


### PR DESCRIPTION
If an SD card is not successfully detected, the device will fall back to use internal flash for logging.